### PR TITLE
Add sections for various logic topics

### DIFF
--- a/I heard that you can build implication gate on Wikipedia.md
+++ b/I heard that you can build implication gate on Wikipedia.md
@@ -62,3 +62,21 @@ Memristor-based implication logic is being explored for:
 3. **Energy-Efficient Logic:** Reducing power consumption in logic circuits.
 
 By using IMPLY gates and memristors, researchers aim to develop next-generation computing systems that are more efficient and scalable.
+
+---
+
+### **Application of Implication Gates in Formal Logic and Computer-Assisted Proof**
+
+Implication gates can also be applied in the field of formal logic and computer-assisted proof. Formal logic involves the use of logical systems to represent and analyze arguments, while computer-assisted proof involves the use of computer programs to assist in the development and verification of mathematical proofs.
+
+#### **1. Formal Logic**
+In formal logic, implication gates can be used to construct logical circuits that represent complex logical expressions. These circuits can then be used to evaluate the truth values of the expressions and verify logical arguments.
+
+#### **Example:**
+Consider the logical expression \( (p \rightarrow q) \land (q \rightarrow r) \). This expression can be represented using implication gates and evaluated to determine its truth value.
+
+#### **2. Computer-Assisted Proof**
+In computer-assisted proof, implication gates can be used to implement logical operations within proof systems. These systems can then be used to verify the correctness of mathematical proofs by evaluating the logical expressions involved.
+
+#### **Example:**
+The proof of a mathematical theorem may involve a series of logical implications. By representing these implications using implication gates, a computer program can evaluate the proof and verify its correctness.

--- a/Logic-Or.md
+++ b/Logic-Or.md
@@ -85,3 +85,46 @@ a \lor b
 \]
 
 This represents the logical simplification of the original statement.
+
+## First-Order Logic
+
+First-order logic (FOL) is a formal system used in mathematics, philosophy, linguistics, and computer science. It extends propositional logic by including quantifiers and predicates, which allows for the expression of statements about objects and their properties.
+
+### Example:
+Consider the statement "All humans are mortal." In first-order logic, this can be expressed as:
+```
+∀x (Human(x) → Mortal(x))
+```
+This reads as "For all x, if x is a human, then x is mortal."
+
+## Fuzzy Logic
+
+Fuzzy logic is a form of many-valued logic that deals with reasoning that is approximate rather than fixed and exact. Unlike classical logic where variables may only be true or false, fuzzy logic variables may have a truth value that ranges between 0 and 1.
+
+### Example:
+In fuzzy logic, the statement "The weather is hot" can have a truth value of 0.7, indicating that it is somewhat hot.
+
+## Modal Logic
+
+Modal logic extends classical logic to include operators expressing modality. Modality refers to concepts like possibility, necessity, and contingency.
+
+### Example:
+The statement "It is necessary that 2+2=4" can be expressed in modal logic as:
+```
+□(2+2=4)
+```
+Where "□" denotes necessity.
+
+## Many-Valued Logic
+
+Many-valued logic is a type of logic in which there are more than two truth values. It generalizes classical two-valued logic.
+
+### Example:
+In a three-valued logic system, a statement can be true, false, or unknown.
+
+## Three-Valued Logic
+
+Three-valued logic is a specific type of many-valued logic where there are three truth values: true, false, and unknown (or indeterminate).
+
+### Example:
+In three-valued logic, the statement "The light is on" can be true, false, or unknown.

--- a/README.md
+++ b/README.md
@@ -215,3 +215,90 @@ https://ncatlab.org/nlab/show/computational+trilogy
 
 20. **你也一樣（Tu Quoque）**：這種謬誤透過指責對方的行為與其主張不一致，來試圖反駁對方的論點，藉此使對方顯得虛偽。然而，這種論證方式並未真正解決所討論的議題。
     - *例子*： 「當某人建議他人戒菸時，對方回應：「你自己也抽菸，憑什麼教訓我？」這種回應並未針對戒菸的益處進行討論，而是轉移焦點至建議者的行為。」
+
+## First-Order Logic
+
+First-order logic (FOL) is a formal system used in mathematics, philosophy, linguistics, and computer science. It extends propositional logic by including quantifiers and predicates, which allows for the expression of statements about objects and their properties.
+
+### Example:
+Consider the statement "All humans are mortal." In first-order logic, this can be expressed as:
+```
+∀x (Human(x) → Mortal(x))
+```
+This reads as "For all x, if x is a human, then x is mortal."
+
+## Fuzzy Logic
+
+Fuzzy logic is a form of many-valued logic that deals with reasoning that is approximate rather than fixed and exact. Unlike classical logic where variables may only be true or false, fuzzy logic variables may have a truth value that ranges between 0 and 1.
+
+### Example:
+In fuzzy logic, the statement "The weather is hot" can have a truth value of 0.7, indicating that it is somewhat hot.
+
+## Modal Logic
+
+Modal logic extends classical logic to include operators expressing modality. Modality refers to concepts like possibility, necessity, and contingency.
+
+### Example:
+The statement "It is necessary that 2+2=4" can be expressed in modal logic as:
+```
+□(2+2=4)
+```
+Where "□" denotes necessity.
+
+## Many-Valued Logic
+
+Many-valued logic is a type of logic in which there are more than two truth values. It generalizes classical two-valued logic.
+
+### Example:
+In a three-valued logic system, a statement can be true, false, or unknown.
+
+## Three-Valued Logic
+
+Three-valued logic is a specific type of many-valued logic where there are three truth values: true, false, and unknown (or indeterminate).
+
+### Example:
+In three-valued logic, the statement "The light is on" can be true, false, or unknown.
+
+## Formal Logic
+
+Formal logic is the study of inference with purely formal content. It involves the use of symbols and rules to represent and analyze logical arguments.
+
+### Example:
+A simple formal logic argument:
+```
+1. All humans are mortal.
+2. Socrates is a human.
+3. Therefore, Socrates is mortal.
+```
+
+## Computer-Assisted Proof
+
+Computer-assisted proof involves the use of computer programs to assist in the development and verification of mathematical proofs.
+
+### Example:
+The proof of the Four Color Theorem, which states that any map can be colored with at most four colors such that no two adjacent regions have the same color, was verified using a computer.
+
+## Predicate Logic
+
+Predicate logic is an extension of propositional logic that includes quantifiers and predicates. It allows for the expression of statements involving variables and their properties.
+
+### Example:
+The statement "There exists a person who is a teacher" can be expressed in predicate logic as:
+```
+∃x (Person(x) ∧ Teacher(x))
+```
+This reads as "There exists an x such that x is a person and x is a teacher."
+
+## Proofs-as-Programs
+
+The proofs-as-programs paradigm, also known as the Curry-Howard correspondence, is a direct relationship between computer programs and mathematical proofs. It states that a proof of a proposition corresponds to a program, and the proposition corresponds to the type of the program.
+
+### Example:
+A proof of the proposition "A implies B" corresponds to a function that takes a proof of A and returns a proof of B.
+
+## Three-State Logic
+
+Three-state logic, also known as ternary logic, is a type of logic in which there are three truth values. It is used in digital electronics to represent three different states: high, low, and high impedance.
+
+### Example:
+In three-state logic, a digital signal can be in one of three states: 1 (high), 0 (low), or Z (high impedance).


### PR DESCRIPTION
Add documentation for various logic topics in `README.md`, `Logic-Or.md`, and `I heard that you can build implication gate on Wikipedia.md`.

* **README.md**
  - Add sections for first-order logic, fuzzy logic, modal logic, many-valued logic, three-valued logic, formal logic, computer-assisted proof, predicate logic, proofs-as-programs, and three-state logic.
  - Provide brief explanations and examples for each new section.

* **Logic-Or.md**
  - Add examples and explanations for first-order logic, fuzzy logic, modal logic, many-valued logic, and three-valued logic.

* **I heard that you can build implication gate on Wikipedia.md**
  - Add a section on the application of implication gates in formal logic and computer-assisted proof.
  - Provide examples and explanations for the new content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ewdlop/Logic-Note/pull/6?shareId=f3547948-fb9b-4046-9b50-39af9e384cbb).